### PR TITLE
Two fixes for Ruby 1.9 support in QMFv1

### DIFF
--- a/qpid/cpp/bindings/qmf/ruby/qmf.rb
+++ b/qpid/cpp/bindings/qmf/ruby/qmf.rb
@@ -26,6 +26,7 @@ module Qmf
 
   # Pull all the TYPE_* constants into Qmf namespace.  Maybe there's an easier way?
   Qmfengine.constants.each do |c|
+    c = c.to_s
     if c.index('TYPE_') == 0 or c.index('ACCESS_') == 0 or c.index('DIR_') == 0 or
         c.index('CLASS_') == 0 or c.index('SEV_') == 0
       const_set(c, Qmfengine.const_get(c))
@@ -348,7 +349,7 @@ module Qmf
       @broker = kwargs[:broker] if kwargs.include?(:broker)
       @allow_sets = :true
 
-      if cls:
+      if cls
         @event_class = cls
         @impl = Qmfengine::Event.new(@event_class.impl)
       elsif kwargs.include?(:impl)
@@ -434,7 +435,7 @@ module Qmf
       @allow_sets = :false
       @broker = kwargs[:broker] if kwargs.include?(:broker)
 
-      if cls:
+      if cls
         @object_class = cls
         @impl = Qmfengine::Object.new(@object_class.impl)
       elsif kwargs.include?(:impl)

--- a/qpid/cpp/bindings/qmf/ruby/qmf.rb
+++ b/qpid/cpp/bindings/qmf/ruby/qmf.rb
@@ -34,8 +34,8 @@ module Qmf
   end
 
   module StringHelpers
-    def ensure_encoding(str, enc=nil)
-      enc ||= (Encoding.default_external.name || "UTF-8" rescue "UTF-8")
+    def ensure_encoding(str)
+      enc = (Encoding.default_external.name || "UTF-8" rescue "UTF-8")
       str.respond_to?(:force_encoding) ? str.force_encoding(enc) : str
     end
   end

--- a/qpid/cpp/bindings/qmf/ruby/qmf.rb
+++ b/qpid/cpp/bindings/qmf/ruby/qmf.rb
@@ -33,12 +33,21 @@ module Qmf
     end
   end
 
+  module StringHelpers
+    def ensure_encoding(str, enc=nil)
+      enc ||= (Encoding.default_external.name || "UTF-8" rescue "UTF-8")
+      str.respond_to?(:force_encoding) ? str.force_encoding(enc) : str
+    end
+  end
+
   class Util
+    include StringHelpers
+
     def qmf_to_native(val)
       case val.getType
       when TYPE_UINT8, TYPE_UINT16, TYPE_UINT32 then val.asUint
       when TYPE_UINT64                          then val.asUint64
-      when TYPE_SSTR, TYPE_LSTR                 then val.asString
+      when TYPE_SSTR, TYPE_LSTR                 then ensure_encoding(val.asString)
       when TYPE_ABSTIME                         then val.asInt64
       when TYPE_DELTATIME                       then val.asUint64
       when TYPE_REF                             then ObjectId.new(val.asObjectId)
@@ -162,6 +171,7 @@ module Qmf
   ##==============================================================================
 
   class ConnectionSettings
+    include StringHelpers
     attr_reader :impl
 
     def initialize(url = nil)
@@ -193,7 +203,7 @@ module Qmf
     def get_attr(key)
       _v = @impl.getAttr(key)
       if _v.isString()
-        return _v.asString()
+        return ensure_encoding(_v.asString())
       elsif _v.isUint()
         return _v.asUint()
       elsif _v.isBool()
@@ -708,6 +718,8 @@ module Qmf
   end
 
   class MethodResponse
+    include StringHelpers
+
     def initialize(impl)
       @impl = Qmfengine::MethodResponse.new(impl)
     end
@@ -721,7 +733,7 @@ module Qmf
     end
 
     def text
-      exception.asString
+      ensure_encoding(exception.asString)
     end
 
     def args
@@ -886,6 +898,7 @@ module Qmf
   end
 
   class SchemaClassKey
+    include StringHelpers
     attr_reader :impl
     def initialize(i)
       @impl = Qmfengine::SchemaClassKey.new(i)
@@ -900,7 +913,7 @@ module Qmf
     end
 
     def to_s
-      @impl.asString
+      ensure_encoding(@impl.asString)
     end
   end
 


### PR DESCRIPTION
The two most recent commits on my fork make QMFv1 work under Ruby 1.9 (which is critical for Fedora 17, among other environments).
