### PR TITLE
QPID-6470: FieldValue::getFloatingPointValue() converts endian each time...

### DIFF
--- a/qpid/cpp/src/qpid/framing/FieldValue.h
+++ b/qpid/cpp/src/qpid/framing/FieldValue.h
@@ -222,9 +222,12 @@ inline T FieldValue::getFloatingPointValue() const {
     FixedWidthValue<W>* const fwv = dynamic_cast< FixedWidthValue<W>* const>(data.get());
     if (fwv) {
         T value;
-        uint8_t* const octets = convertIfRequired(fwv->rawOctets(), W);
         uint8_t* const target = reinterpret_cast<uint8_t*>(&value);
+        uint8_t* octets = fwv->rawOctets();
         for (size_t i = 0; i < W; ++i) target[i] = octets[i];
+
+        convertIfRequired(reinterpret_cast<uint8_t* const>(&value), W);
+
         return value;
     } else {
         throw InvalidConversionException();


### PR DESCRIPTION
When calling getFloatingPointValue multiple times, the octets are endian-converted each time.
Actually we need to make a copy first and then call convertIfRequired().
