### PR TITLE
Get qpid C++ building on OSX.

### DIFF
--- a/qpid/cpp/CMakeLists.txt
+++ b/qpid/cpp/CMakeLists.txt
@@ -29,6 +29,8 @@ project(qpid-cpp)
 cmake_minimum_required(VERSION 2.6 FATAL_ERROR)
 if(COMMAND cmake_policy)
   cmake_policy(VERSION 2.6)
+  # Use @rpath on OSX
+  cmake_policy(SET CMP0042 NEW)
 endif(COMMAND cmake_policy)
 
 if (${CMAKE_VERSION} VERSION_LESS "2.8.0")

--- a/qpid/cpp/INSTALL
+++ b/qpid/cpp/INSTALL
@@ -158,6 +158,17 @@ the shared libraries built as part of Qpid.
 The mktemp package must be installed separately in order to execute the
 Qpid test suite.
 
+2.5 Building on OSX
+===================
+Qpid has been tested on OSX 10.10 with Clang 6.0 and Boost 1.57. Boost 1.57 requires
+C++11 support. SASL support has not been tested. The cmake command line should be:
+
+ # cmake -DBUILD_SASL=no -DBUILD_PROBES=no -DCMAKE_CXX_FLAGS="-std=c++11 -Wno-error=deprecated-declarations" ..
+
+Dependencies can be installed from homebrew (http://brew.sh/) using:
+
+ # brew install cmake boost ossp-uuid pkgconfig help2man doxygen grpahviz swig boost sleepycat berkeley-db
+
 3. Building a Repository Working Copy
 =====================================
 To get the source code from the subversion repository (trunk) do:

--- a/qpid/cpp/src/CMakeLists.txt
+++ b/qpid/cpp/src/CMakeLists.txt
@@ -310,16 +310,19 @@ endif (UUID_GENERATE_IN_LIBC)
 
 # These dependencies aren't found on windows
 if (NOT CMAKE_SYSTEM_NAME STREQUAL Windows)
-  # Ensure we have clock_gettime
-  CHECK_FUNCTION_EXISTS (clock_gettime CLOCK_GETTIME_IN_LIBC)
-  if (NOT CLOCK_GETTIME_IN_LIBC)
-  CHECK_LIBRARY_EXISTS (rt clock_gettime "" CLOCK_GETTIME_IN_RT)
-  if (CLOCK_GETTIME_IN_RT)
-    set(clock_gettime_LIB "rt")
-  else ()
-    message(FATAL_ERROR "Cannot find clock_gettime()")
-  endif (CLOCK_GETTIME_IN_RT)
-  endif (NOT CLOCK_GETTIME_IN_LIBC)
+  # Clocks on OSX are different
+  if (NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
+    # Ensure we have clock_gettime
+    CHECK_FUNCTION_EXISTS (clock_gettime CLOCK_GETTIME_IN_LIBC)
+    if (NOT CLOCK_GETTIME_IN_LIBC)
+    CHECK_LIBRARY_EXISTS (rt clock_gettime "" CLOCK_GETTIME_IN_RT)
+    if (CLOCK_GETTIME_IN_RT)
+      set(clock_gettime_LIB "rt")
+    else ()
+      message(FATAL_ERROR "Cannot find clock_gettime()")
+    endif (CLOCK_GETTIME_IN_RT)
+    endif (NOT CLOCK_GETTIME_IN_LIBC)
+  endif (NOT CMAKE_SYSTEM_NAME STREQUAL OSX)
 
   # Check for header file for dtrace static probes
   check_include_files(sys/sdt.h HAVE_SDT)

--- a/qpid/cpp/src/qpid/store/CMakeLists.txt
+++ b/qpid/cpp/src/qpid/store/CMakeLists.txt
@@ -54,8 +54,12 @@ if (CMAKE_SYSTEM_NAME STREQUAL Windows)
 endif (CMAKE_SYSTEM_NAME STREQUAL Windows)
 
 set_target_properties (store PROPERTIES
-                       COMPILE_DEFINITIONS _IN_QPID_BROKER
-                       VERSION ${qpidc_version})
+                       COMPILE_DEFINITIONS _IN_QPID_BROKER)
+if (NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
+  set_target_properties (store PROPERTIES
+                         VERSION ${qpidc_version})
+endif (NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
+
 install (TARGETS store # RUNTIME
          DESTINATION ${QPIDD_MODULE_DIR}
          COMPONENT ${QPID_COMPONENT_BROKER})

--- a/qpid/cpp/src/qpid/sys/posix/Condition.cpp
+++ b/qpid/cpp/src/qpid/sys/posix/Condition.cpp
@@ -31,7 +31,13 @@ struct ClockMonotonicAttr {
 
     ClockMonotonicAttr() {
         QPID_POSIX_ASSERT_THROW_IF(pthread_condattr_init(&attr));
+#ifdef __MACH__
+        // OSX doesn't let you set the clock, and absolute pthread
+        // waits are always based on gettimeofday. Not sure what to
+        // do.
+#else
         QPID_POSIX_ASSERT_THROW_IF(pthread_condattr_setclock(&attr, CLOCK_MONOTONIC));
+#endif
     }
 };
 

--- a/qpid/cpp/src/qpid/sys/posix/PosixPoller.cpp
+++ b/qpid/cpp/src/qpid/sys/posix/PosixPoller.cpp
@@ -681,9 +681,9 @@ void Poller::run() {
     // Ensure that we exit thread responsibly under all circumstances
     try {
         // Make sure we can't be interrupted by signals at a bad time
-        ::sigset_t ss;
-        ::sigfillset(&ss);
-        ::pthread_sigmask(SIG_SETMASK, &ss, 0);
+        sigset_t ss;
+        sigfillset(&ss);
+        pthread_sigmask(SIG_SETMASK, &ss, 0);
 
         ++(impl->threadCount);
         do {

--- a/qpid/cpp/src/qpid/sys/posix/PrivatePosix.h
+++ b/qpid/cpp/src/qpid/sys/posix/PrivatePosix.h
@@ -38,10 +38,6 @@ namespace sys {
 // Private Time related implementation details
 struct timespec& toTimespec(struct timespec& ts, const AbsTime& t);
 struct timeval& toTimeval(struct timeval& tv, const Duration& t);
-//Duration toTime(const struct timespec& ts);
-//#ifdef __MACH__
-//Duration toTime(const mach_timespec_t& ts);
-//#endif
 
 // Private SocketAddress details
 class SocketAddress;

--- a/qpid/cpp/src/qpid/sys/posix/PrivatePosix.h
+++ b/qpid/cpp/src/qpid/sys/posix/PrivatePosix.h
@@ -24,6 +24,10 @@
 
 #include "qpid/sys/Time.h"
 
+#ifdef __MACH__
+#include <mach/clock.h>
+#endif
+
 struct timespec;
 struct timeval;
 struct addrinfo;
@@ -34,7 +38,10 @@ namespace sys {
 // Private Time related implementation details
 struct timespec& toTimespec(struct timespec& ts, const AbsTime& t);
 struct timeval& toTimeval(struct timeval& tv, const Duration& t);
-Duration toTime(const struct timespec& ts);
+//Duration toTime(const struct timespec& ts);
+//#ifdef __MACH__
+//Duration toTime(const mach_timespec_t& ts);
+//#endif
 
 // Private SocketAddress details
 class SocketAddress;

--- a/qpid/cpp/src/qpid/sys/regex.h
+++ b/qpid/cpp/src/qpid/sys/regex.h
@@ -19,7 +19,7 @@
  *
  */
 
-#if defined(_POSIX_SOURCE) || defined(__unix__)
+#if defined(_POSIX_SOURCE) || defined(__unix__) || defined(__MACH__)
 # include <stdexcept>
 # include <string>
 # include <regex.h>
@@ -38,7 +38,7 @@
 namespace qpid {
 namespace sys {
 
-#if defined(_POSIX_SOURCE) || defined(__unix__)
+#if defined(_POSIX_SOURCE) || defined(__unix__) || defined(__MACH__)
 
 class regex {
     ::regex_t re;


### PR DESCRIPTION
QPID-2536: Implement posix clock_gettime
QPID-4280: clock_gettime not available on Mac OS X
QPID-4278: Broken OS X Build

Add documentation to INSTALL and fix up build scripts
Conditionalize posix clock routines for **MACH**
sigfillset is a macro on osx.
Open question around absolute time pthread wait()s.
