### PR TITLE
NO-JIRA: Fixed .NET Native-Managed string convervsion

### DIFF
--- a/qpid/cpp/bindings/qpid/dotnet/src/Message.cpp
+++ b/qpid/cpp/bindings/qpid/dotnet/src/Message.cpp
@@ -441,7 +441,7 @@ namespace Messaging {
 
         try
         {
-            result = gcnew String(nativeObjPtr->getContent().c_str());
+            result = QpidMarshal::ToManaged(nativeObjPtr->getContent().c_str());
         }
         catch (const ::qpid::types::Exception & error)
         {

--- a/qpid/cpp/bindings/qpid/dotnet/src/QpidMarshal.h
+++ b/qpid/cpp/bindings/qpid/dotnet/src/QpidMarshal.h
@@ -60,6 +60,23 @@ public:
         std::string native((char *) pinnedBuf, mbytes->Length);
         return native;
     }
+
+
+    static System::String^ ToManaged( std::string native )
+    {
+        if( native.length() == 0 )
+        {
+            return gcnew System::String( "" );
+        }
+
+        pin_ptr<unsigned char> pinnedBuf = (unsigned char *)native.c_str();
+        array<unsigned char>^ mbytes = gcnew array<unsigned char>( native.length() );
+
+        for( unsigned int idx = 0; idx < native.length(); idx++ )
+            mbytes[ idx ] = pinnedBuf[ idx ];
+
+        return Encoding::UTF8->GetString( mbytes );
+    }
 };
 
 }}}}

--- a/qpid/cpp/bindings/qpid/dotnet/src/TypeTranslator.cpp
+++ b/qpid/cpp/bindings/qpid/dotnet/src/TypeTranslator.cpp
@@ -280,7 +280,7 @@ namespace Messaging {
         //  create a .NET object and add it to the dictionary.
         for (::qpid::types::Variant::Map::const_iterator i = qpidMap.begin(); i != qpidMap.end(); ++i)
         {
-            System::String ^ elementName = gcnew String(i->first.c_str());
+            System::String ^ elementName = QpidMarshal::ToNative(i->first.c_str());;
             ::qpid::types::Variant variant = i->second;
             dict[elementName] = NativeToManagedObject(variant);
         }
@@ -394,7 +394,7 @@ namespace Messaging {
 
         case ::qpid::types::VAR_STRING:
             {
-                System::String ^ elementValue = gcnew System::String(nativeObject.asString().c_str());
+                System::String ^ elementValue = QpidMarshal::ToManaged(nativeObject.asString().c_str());
                 managedObject = elementValue;
                 break;
             }


### PR DESCRIPTION
The string conversion was not correct when you wanted to convert from
native UTF-8 string to a managed one. A conversion method has ben added
to QpidMarshal and it is called from Message and TypeTranslator when
necessary.
