### PR TITLE
feat(disposition): respect messageAnnotation mods in modified state

### DIFF
--- a/qpid/cpp/src/qpid/broker/Queue.cpp
+++ b/qpid/cpp/src/qpid/broker/Queue.cpp
@@ -345,6 +345,19 @@ void Queue::process(Message& msg)
     }
 }
 
+void Queue::mergeMessageAnnotations(const QueueCursor& position,
+                                    const qpid::types::Variant::Map& messageAnnotations)
+{
+  Mutex::ScopedLock locker(messageLock);
+  Message *message = messages->find(position);
+  if (!message) return;
+
+  qpid::types::Variant::Map::const_iterator it;
+  for (it = messageAnnotations.begin(); it != messageAnnotations.end(); ++it) {
+    message->addAnnotation(it->first, it->second);
+  }
+}
+
 void Queue::release(const QueueCursor& position, bool markRedelivered)
 {
     QueueListeners::NotificationSet copy;

--- a/qpid/cpp/src/qpid/broker/Queue.h
+++ b/qpid/cpp/src/qpid/broker/Queue.h
@@ -332,6 +332,13 @@ class Queue : public boost::enable_shared_from_this<Queue>,
     QPID_BROKER_EXTERN void deliverTo(Message, TxBuffer* = 0);
   public:
     /**
+     * Merges message annotations for an in-memory message as a result of
+     * a modified disposition outcome
+     */
+    QPID_BROKER_EXTERN void mergeMessageAnnotations(const QueueCursor& msg,
+                                                    const qpid::types::Variant::Map& annotations);
+
+    /**
      * Returns a message to the in-memory queue (due to lack
      * of acknowledegement from a receiver). If a consumer is
      * available it will be dispatched immediately, else it

--- a/qpid/cpp/src/qpid/broker/amqp/Outgoing.h
+++ b/qpid/cpp/src/qpid/broker/amqp/Outgoing.h
@@ -152,6 +152,8 @@ class OutgoingFromQueue : public Outgoing, public qpid::broker::Consumer,
         static size_t getIndex(pn_delivery_tag_t);
     };
 
+    void mergeMessageAnnotationsIfRequired(const Record &r);
+
     const bool exclusive;
     const bool isControllingUser;
     boost::shared_ptr<Queue> queue;


### PR DESCRIPTION
The modified outcome supports an optional messageAnnotations parameter, allowing the user to modify these annotations for subsequent redelivery with updated valus. This patch implements this behavior in qpidd

/cc @grs
